### PR TITLE
removed some bfd64 code

### DIFF
--- a/valgrind/fjalar/readelf.c
+++ b/valgrind/fjalar/readelf.c
@@ -1225,10 +1225,8 @@ dump_relocations (FILE * file,
 	  FJALAR_DPRINTF (do_wide
 		  ? "%8.8lx%8.8lx  %8.8lx%8.8lx "
 		  : "%4.4lx%8.8lx  %4.4lx%8.8lx ",
-		  _bfd_int64_high (offset),
-		  _bfd_int64_low (offset),
-		  _bfd_int64_high (inf),
-		  _bfd_int64_low (inf));
+		  (offset), (offset),
+		  (inf), (inf));
 #endif
 	}
 


### PR DESCRIPTION
Hello,

I have been trying to use your tool. Unfortunately it cannot compile on my system because of these _bfd_int64_low/high macros (they're not in my bfd.h). It looks like the uses of them have been removed everywhere else in this file, so I think they are there by mistake.