### PR TITLE
support all frame-base types; improve function entry discovery

### DIFF
--- a/valgrind/fjalar/fjalar_include.h
+++ b/valgrind/fjalar/fjalar_include.h
@@ -607,10 +607,11 @@ typedef struct _FunctionEntry {
   // True if globally visible, False if file-static scope
   Bool isExternal;
 
-  // True if there's a location list for this function
-  Bool locList;
-
-  unsigned long locListOffset;
+  enum dwarf_location_atom frame_base_atom;
+  // If frame_base_atom == DW_OP_list, then frame_base_offset is a pointer
+  // to a location list; otherwise, it is an offset from the register
+  // indicated by frame_base_atom.
+  long frame_base_offset;
 
   VarList formalParameters;        // List of formal parameter variables
 
@@ -1076,7 +1077,6 @@ Bool fjalar_output_struct_vars;            // --output-struct-vars
 Bool fjalar_flatten_arrays;                // --flatten-arrays
 Bool fjalar_func_disambig_ptrs;            // --func-disambig-ptrs
 Bool fjalar_disambig_ptrs;                 // --disambig-ptrs
-Bool fjalar_gcc3;                          // --gcc3
 
 int  fjalar_array_length_limit;            // --array-length-limit
 

--- a/valgrind/fjalar/generate_fjalar_entries.c
+++ b/valgrind/fjalar/generate_fjalar_entries.c
@@ -1650,9 +1650,10 @@ void initializeFunctionTable(void)
           cur_func_entry->cuBase = dwarfFunctionPtr->comp_pc;
           cur_func_entry->endPC = dwarfFunctionPtr->end_pc;
 
-          FJALAR_DPRINTF("Frame base exp is:%u - %d\n", dwarfFunctionPtr->frame_base_expression, DW_OP_list);
-          cur_func_entry->locList = (dwarfFunctionPtr->frame_base_expression == DW_OP_list);
-          cur_func_entry->locListOffset = dwarfFunctionPtr->frame_base_offset;
+          FJALAR_DPRINTF("Frame base exp is: %u + %ld\n", dwarfFunctionPtr->frame_base_expression,
+                                                         dwarfFunctionPtr->frame_base_offset);
+          cur_func_entry->frame_base_atom = dwarfFunctionPtr->frame_base_expression;
+          cur_func_entry->frame_base_offset = dwarfFunctionPtr->frame_base_offset;
 
 
           cur_func_entry->isExternal = dwarfFunctionPtr->is_external;
@@ -3409,6 +3410,8 @@ static void XMLprintOneFunction(FunctionEntry* cur_entry,
 
   XML_PRINTF("<start-PC>%p</start-PC>\n",
              (void*)cur_entry->startPC);
+  XML_PRINTF("<entry-PC>%p</entry-PC>\n",
+             (void*)cur_entry->entryPC);
   XML_PRINTF("<end-PC>%p</end-PC>\n",
              (void*)cur_entry->endPC);
 

--- a/valgrind/fjalar/typedata.h
+++ b/valgrind/fjalar/typedata.h
@@ -64,7 +64,7 @@ typedef struct
 
 // Entries for individual types
 
-// RUDD - struct representing the location list.
+// Struct representing the location list.
 // Representned as a linked list.
 typedef struct _location_list
 {
@@ -76,7 +76,7 @@ typedef struct _location_list
   struct _location_list *next;
 } location_list;
 
-// RUDD - struct representing a debug_frame block.
+// Struct representing a debug_frame block.
 // Represented as a linked list.
 typedef struct _debug_frame
 {
@@ -424,6 +424,8 @@ extern dwarf_entry* dwarf_entry_array;
 extern compile_unit** comp_unit_info;
 extern unsigned long dwarf_entry_array_size;
 extern location_list *debug_loc_list;
+extern Bool clang_producer;
+extern Bool other_producer;
 
 unsigned int hashString(const char* str);
 int equivalentStrings(char* str1, char* str2);
@@ -514,6 +516,7 @@ char harvest_const_value(dwarf_entry* e, unsigned long value);
 char harvest_name(dwarf_entry* e, const char* str);
 char harvest_mangled_name(dwarf_entry* e, const char* str);
 char harvest_comp_dir(dwarf_entry* e, const char* str);
+char harvest_producer(dwarf_entry* e, const char* str);
 char harvest_formal_param_location_offset(dwarf_entry* e, long value);
 char harvest_formal_param_location_atom(dwarf_entry* e, enum dwarf_location_atom atom, long value);
 char harvest_data_member_location(dwarf_entry* e, unsigned long value);


### PR DESCRIPTION
support simple frame base expressions - allows clang generated binaries to be processed correctly
improve function entry point discovery - remove unnecessarily complicated code